### PR TITLE
#167106746 cancel trip endpoint

### DIFF
--- a/index.js
+++ b/index.js
@@ -9,7 +9,7 @@ import routeHandler from './src/routes';
 const app = express();
 
 // Declare PORT
-const port = process.env.PORT || 5000;
+const port = process.env.PORT || 3000;
 
 // Set body parser to make parameter acceptable
 app.use(parser.json());

--- a/src/controllers/trip.js
+++ b/src/controllers/trip.js
@@ -4,7 +4,9 @@
 import tripQueries from '../helpers/tripQueries';
 import db from '../db/connect';
 
-const { createTripQuery, findBusQuery, getAllTripsQuery } = tripQueries;
+const {
+  createTripQuery, findBusQuery, getAllTripsQuery, cancelTripQuery,
+} = tripQueries;
 
 
 class TripController {
@@ -77,6 +79,31 @@ class TripController {
             data: trips,
           });
         }
+      })
+      .catch(err => console.log(err));
+  }
+
+
+  static cancelTrip(req, res) {
+    const { token, userId, isAdmin } = req.body;
+    const { tripId } = req.params;
+
+
+    db.query(cancelTripQuery, ['cancelled', tripId])
+      .then((result) => {
+        const cancelledTrip = result.rows[0];
+
+        if (!cancelledTrip) {
+          res.status(404).json({
+            error: 'Trip neither found nor updated',
+          });
+          return;
+        }
+
+        res.status(205).json({
+          status: 205,
+          message: 'Trip cancelled successfully',
+        });
       })
       .catch(err => console.log(err));
   }

--- a/src/routes/trip.js
+++ b/src/routes/trip.js
@@ -9,5 +9,7 @@ router.post('/', auth, TripController.createTrip);
 
 router.get('/', TripController.getTrips);
 
+router.patch('/:tripId', auth, TripController.cancelTrip);
+
 
 module.exports = router;

--- a/src/test/booking.spec.js
+++ b/src/test/booking.spec.js
@@ -1,5 +1,6 @@
 /* eslint-disable no-unused-vars */
 /* eslint-disable no-console */
+/* eslint-disable max-len */
 /* eslint-disable no-undef */
 /* eslint-disable no-unused-expressions */
 import chai, { should } from 'chai';
@@ -160,7 +161,7 @@ describe('Testing Bookings Endpoints', () => {
 
   it('Delete Booking method (DELETE) should delete a specific booking', (done) => {
     chai.request(server)
-      .delete('/api/v1/bookings/1')
+      .delete('/api/v1/bookings/4')
       .end((err, res) => {
         res.should.have.status(200);
         res.should.be.json;
@@ -172,6 +173,7 @@ describe('Testing Bookings Endpoints', () => {
       });
     done();
   });
+
   it('Delete Booking method (DELETE) should return an ERROR if booking is not found', (done) => {
     chai.request(server)
       .delete('/api/v1/bookings/0')
@@ -186,6 +188,7 @@ describe('Testing Bookings Endpoints', () => {
       });
     done();
   });
+
   it('Delete Booking method (DELETE) should return an ERROR if booking is found but not deleted', (done) => {
     chai.request(server)
       .delete('/api/v1/bookings/1')

--- a/src/test/trip.spec.js
+++ b/src/test/trip.spec.js
@@ -112,7 +112,7 @@ before((done) => {
           TripController.getTrips.should.exist;
         });
 
-        it('Get Trips method (POST) should retrieve all available trips on record', (done) => {
+        it('Get Trips method (GET) should retrieve all available trips on record', (done) => {
           chai.request(server)
             .get('/api/v1/trips')
             .end((err, res) => {
@@ -126,7 +126,49 @@ before((done) => {
             });
           done();
         });
-      });
+
+        it('Cancel Trip method (PATCH) should exist', () => {
+          TripController.cancelTrip.should.exist;
+        });
+
+        it('Cancel Trip method (PATCH) should cancel a specific trip', (done) => {
+          chai.request(server)
+            .patch('/api/v1/trips/1')
+            .set('Authorization', `Bearer ${adminToken}`)
+            .send({
+              status: 'cancelled',
+            })
+            .end((err, res) => {
+              res.should.have.status(205);
+              res.should.be.json;
+              res.body.should.be.a('object');
+              res.body.should.be.have.property('status');
+              res.body.should.be.have.property('message');
+              res.body.status.should.equal(205);
+              res.body.data.should.be.a('string');
+            });
+          done();
+        });
+
+        it('Cancel Trip method (PATCH) should return an ERROR if trip is not found', (done) => {
+          chai.request(server)
+            .patch('/api/v1/trips/0')
+            .set('Authorization', `Bearer ${adminToken}`)
+            .send({
+              status: 'cancelled',
+            })
+            .end((err, res) => {
+              res.should.have.status(404);
+              res.should.be.json;
+              res.body.should.be.a('object');
+              res.body.should.be.have.property('status');
+              res.body.should.be.have.property('error');
+              res.body.status.should.equal(404);
+              res.body.data.should.be.a('string');
+            });
+          done();
+        });
+      }); // End of top level 'describe' function
     });
   done();
-});
+}); // End of before hook function


### PR DESCRIPTION
What does this PR do?
Add a PATCH route for admin to be able to cancel a specific trip

Description of Task to be completed?
Get the following endpoint working
PATCH api/v1/trips/:id

How should this be manually tested?
Clone the repo, and run 'npm start'
Test the endpoint with Postman

Any background context you want to provide? NA
What are the relevant pivotal tracker stories? NA

Screenshots (if appropriate) NA
Questions: NA